### PR TITLE
Sentiment-Analysis

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -11,6 +11,12 @@
         <relativePath/>
     </parent>
 
+    <repositories>
+        <repository>
+            <id>stanford-corenlp</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        </repository>
+    </repositories>
     <groupId>com.group4</groupId>
     <artifactId>vibeWrite</artifactId>
     <version>0.0.1-SNAPSHOT</version>
@@ -117,6 +123,51 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>edu.stanford.nlp</groupId>
+            <artifactId>stanford-corenlp</artifactId>
+            <version>4.5.0</version>
+            <classifier>models</classifier>
+        </dependency>
+        <dependency>
+            <groupId>edu.stanford.nlp</groupId>
+            <artifactId>stanford-corenlp</artifactId>
+            <version>4.5.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>4.0.2</version> </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>4.0.5</version>
+        </dependency>
+
+        <!-- JAXB Dependencies -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.3.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/backend/src/main/java/com/group4/vibeWrite/Config/SecurityConfig.java
+++ b/backend/src/main/java/com/group4/vibeWrite/Config/SecurityConfig.java
@@ -55,6 +55,7 @@ public class SecurityConfig {
                                 "/api/analyze/**",
                                 "/api/v1/notifications/**",
                                 "/api/v1/grammar/**",
+                                "/api/v1/semantic-analysis/**",
                                 "/api/test",           // Test endpoint
                                 "/api/health"          // Health check
                         ).permitAll()

--- a/backend/src/main/java/com/group4/vibeWrite/SemanticAnalysis/controller/SemanticAnalysisController.java
+++ b/backend/src/main/java/com/group4/vibeWrite/SemanticAnalysis/controller/SemanticAnalysisController.java
@@ -1,0 +1,219 @@
+package com.group4.vibeWrite.SemanticAnalysis.controller;
+
+import com.group4.vibeWrite.SemanticAnalysis.dto.SemanticAnalysisRequest;
+import com.group4.vibeWrite.SemanticAnalysis.dto.SemanticAnalysisResponse;
+import com.group4.vibeWrite.SemanticAnalysis.entity.SemanticAnalysisHistory;
+import com.group4.vibeWrite.SemanticAnalysis.service.SemanticAnalysisOrchestrator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/v1/semantic-analysis")
+@RequiredArgsConstructor
+@Slf4j
+@CrossOrigin(origins = "${frontend.url:*}")
+public class SemanticAnalysisController {
+
+    private final SemanticAnalysisOrchestrator orchestrator;
+
+    @PostMapping("/analyze")
+    public ResponseEntity<SemanticAnalysisResponse> analyzeText(@Valid @RequestBody SemanticAnalysisRequest request) {
+        try {
+            log.info("Semantic analysis requested for text length: {}", request.getText().length());
+            String userId = request.getUserId();
+            SemanticAnalysisResponse response = orchestrator.performCompleteAnalysis(request, userId);
+            log.info("Semantic analysis completed. Score: {}", response.getComplexityScore());
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            log.warn("Invalid semantic analysis request: {}", e.getMessage());
+            return ResponseEntity.badRequest().build();
+        } catch (Exception e) {
+            log.error("Error processing semantic analysis: ", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    @PostMapping("/analyze-anonymous")
+    public ResponseEntity<SemanticAnalysisResponse> analyzeTextAnonymous(@Valid @RequestBody SemanticAnalysisRequest request) {
+        try {
+            log.info("Anonymous semantic analysis requested for text length: {}", request.getText().length());
+            SemanticAnalysisResponse response = orchestrator.performCompleteAnalysis(request, null);
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            log.error("Error processing anonymous semantic analysis: ", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    @PostMapping("/tokenize")
+    public ResponseEntity<List<String>> tokenize(@Valid @RequestBody SemanticAnalysisRequest request) {
+        try {
+            return ResponseEntity.ok(orchestrator.getTokenizeService().tokenizeText(request.getText()));
+        } catch (Exception e) {
+            log.error("Error in tokenization: ", e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    @PostMapping("/sentences")
+    public ResponseEntity<List<String>> recognizeSentences(@Valid @RequestBody SemanticAnalysisRequest request) {
+        try {
+            return ResponseEntity.ok(orchestrator.getSentenceRecognizerService().recognizeSentences(request.getText()));
+        } catch (Exception e) {
+            log.error("Error in sentence recognition: ", e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    @PostMapping("/pos")
+    public ResponseEntity<Map<String, String>> getPOSTags(@Valid @RequestBody SemanticAnalysisRequest request) {
+        try {
+            return ResponseEntity.ok(orchestrator.getPosService().getPOSTags(request.getText()));
+        } catch (Exception e) {
+            log.error("Error in POS tagging: ", e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    @PostMapping("/lemma")
+    public ResponseEntity<Map<String, String>> lemmatize(@Valid @RequestBody SemanticAnalysisRequest request) {
+        try {
+            return ResponseEntity.ok(orchestrator.getLemmaService().lemmatizeText(request.getText()));
+        } catch (Exception e) {
+            log.error("Error in lemmatization: ", e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    @PostMapping("/ner")
+    public ResponseEntity<Map<String, String>> extractNamedEntities(@Valid @RequestBody SemanticAnalysisRequest request) {
+        try {
+            return ResponseEntity.ok(orchestrator.getNerService().extractNamedEntities(request.getText()));
+        } catch (Exception e) {
+            log.error("Error in NER: ", e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    @PostMapping("/sentiment")
+    public ResponseEntity<Map<String, String>> analyzeSentiment(@Valid @RequestBody SemanticAnalysisRequest request) {
+        try {
+            return ResponseEntity.ok(orchestrator.getSentimentAnalysisService().analyzeSentiment(request.getText()));
+        } catch (Exception e) {
+            log.error("Error in sentiment analysis: ", e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    @GetMapping("/history/user/{userId}")
+    public ResponseEntity<List<SemanticAnalysisHistory>> getSemanticHistory(@PathVariable String userId) {
+        try {
+            if (userId == null || userId.trim().isEmpty()) {
+                return ResponseEntity.badRequest().build();
+            }
+            List<SemanticAnalysisHistory> history = orchestrator.getUserSemanticHistory(userId);
+            return ResponseEntity.ok(history);
+        } catch (Exception e) {
+            log.error("Error retrieving semantic history for userId {}: ", userId, e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    @GetMapping("/history/{id}")
+    public ResponseEntity<SemanticAnalysisHistory> getSemanticAnalysisById(@PathVariable String id) {
+        try {
+            Optional<SemanticAnalysisHistory> analysis = orchestrator.getSemanticAnalysisById(id);
+            return analysis.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+        } catch (Exception e) {
+            log.error("Error retrieving semantic analysis by ID: ", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    @GetMapping("/history/paginated")
+    public ResponseEntity<Page<SemanticAnalysisHistory>> getSemanticHistoryPaginated(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            Authentication authentication) {
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        try {
+            String userId = authentication.getName();
+            Pageable pageable = PageRequest.of(page, size);
+            Page<SemanticAnalysisHistory> history = orchestrator.getUserSemanticHistory(userId, pageable);
+            return ResponseEntity.ok(history);
+        } catch (Exception e) {
+            log.error("Error retrieving paginated semantic history: ", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    @GetMapping("/stats")
+    public ResponseEntity<Map<String, Object>> getSemanticStats(Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        try {
+            String userId = authentication.getName();
+            Map<String, Object> stats = orchestrator.getUserSemanticStats(userId);
+            return ResponseEntity.ok(stats);
+        } catch (Exception e) {
+            log.error("Error retrieving semantic stats: ", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    @GetMapping("/stats/detailed")
+    public ResponseEntity<Map<String, Object>> getDetailedSemanticStats(Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        try {
+            String userId = authentication.getName();
+            Map<String, Object> stats = orchestrator.getDetailedUserStats(userId);
+            return ResponseEntity.ok(stats);
+        } catch (Exception e) {
+            log.error("Error retrieving detailed semantic stats: ", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    @GetMapping("/trends")
+    public ResponseEntity<Map<String, Object>> getAnalysisTrends(Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        try {
+            String userId = authentication.getName();
+            Map<String, Object> trends = orchestrator.getAnalysisTrends(userId);
+            return ResponseEntity.ok(trends);
+        } catch (Exception e) {
+            log.error("Error retrieving analysis trends: ", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    @GetMapping("/health")
+    public ResponseEntity<Map<String, String>> health() {
+        return ResponseEntity.ok(Map.of(
+                "status", "UP",
+                "service", "Semantic Analysis Service",
+                "timestamp", String.valueOf(System.currentTimeMillis())
+        ));
+    }
+}
+

--- a/backend/src/main/java/com/group4/vibeWrite/SemanticAnalysis/dto/SemanticAnalysisRequest.java
+++ b/backend/src/main/java/com/group4/vibeWrite/SemanticAnalysis/dto/SemanticAnalysisRequest.java
@@ -1,0 +1,21 @@
+package com.group4.vibeWrite.SemanticAnalysis.dto;
+
+import lombok.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Getter
+@Setter
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SemanticAnalysisRequest {
+
+    private String userId;
+
+    @NotBlank(message = "Text cannot be empty")
+    @Size(max = 10000, message = "Text cannot exceed 10000 characters")
+    private String text;
+
+    private String language = "en";
+}

--- a/backend/src/main/java/com/group4/vibeWrite/SemanticAnalysis/dto/SemanticAnalysisResponse.java
+++ b/backend/src/main/java/com/group4/vibeWrite/SemanticAnalysis/dto/SemanticAnalysisResponse.java
@@ -1,0 +1,49 @@
+package com.group4.vibeWrite.SemanticAnalysis.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SemanticAnalysisResponse {
+
+    private String originalText;
+    private List<String> tokens;
+    private List<String> sentences;
+    private Map<String, String> posTags;
+    private Map<String, String> lemmas;
+    private Map<String, String> namedEntities;
+    private Map<String, String> sentiment;
+
+    private SemanticMetrics metrics;
+    private int complexityScore;
+    private LocalDateTime analyzedAt;
+    private String error;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class SemanticMetrics {
+        private int wordCount;
+        private int sentenceCount;
+        private int uniqueWordCount;
+        private int namedEntityCount;
+        private double averageWordsPerSentence;
+        private double lexicalDiversity;
+        private double readabilityScore;
+        private Map<String, Integer> posTagCounts;
+        private Map<String, Integer> sentimentDistribution;
+        private Map<String, Integer> entityTypeCounts;
+        private double semanticDensity;
+    }
+}
+

--- a/backend/src/main/java/com/group4/vibeWrite/SemanticAnalysis/entity/SemanticAnalysisHistory.java
+++ b/backend/src/main/java/com/group4/vibeWrite/SemanticAnalysis/entity/SemanticAnalysisHistory.java
@@ -1,0 +1,78 @@
+package com.group4.vibeWrite.SemanticAnalysis.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.index.Indexed;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Document(collection = "semantic_analysis_history")
+public class SemanticAnalysisHistory {
+
+    @Id
+    private String id;
+
+    @Indexed
+    private String userId;
+
+    private String originalText;
+    private List<String> tokens;
+    private List<String> sentences;
+    private Map<String, String> posTags;
+    private Map<String, String> lemmas;
+    private Map<String, String> namedEntities;
+    private Map<String, String> sentiment;
+
+    private SemanticMetrics metrics;
+    private int complexityScore;
+
+    @Indexed
+    private LocalDateTime analyzedAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SemanticMetrics {
+        private int wordCount;
+        private int sentenceCount;
+        private int uniqueWordCount;
+        private int namedEntityCount;
+        private double averageWordsPerSentence;
+        private double lexicalDiversity;
+        private double readabilityScore;
+        private Map<String, Integer> posTagCounts;
+        private Map<String, Integer> sentimentDistribution;
+        private Map<String, Integer> entityTypeCounts;
+        private double semanticDensity;
+    }
+
+    public SemanticAnalysisHistory(String userId, String originalText, List<String> tokens,
+                                   List<String> sentences, Map<String, String> posTags,
+                                   Map<String, String> lemmas, Map<String, String> namedEntities,
+                                   Map<String, String> sentiment, SemanticMetrics metrics,
+                                   int complexityScore) {
+        this.userId = userId;
+        this.originalText = originalText;
+        this.tokens = tokens;
+        this.sentences = sentences;
+        this.posTags = posTags;
+        this.lemmas = lemmas;
+        this.namedEntities = namedEntities;
+        this.sentiment = sentiment;
+        this.metrics = metrics;
+        this.complexityScore = complexityScore;
+        this.analyzedAt = LocalDateTime.now();
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/group4/vibeWrite/SemanticAnalysis/exception/SemanticAnalysisExceptionHandler.java
+++ b/backend/src/main/java/com/group4/vibeWrite/SemanticAnalysis/exception/SemanticAnalysisExceptionHandler.java
@@ -1,0 +1,82 @@
+package com.group4.vibeWrite.SemanticAnalysis.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import jakarta.validation.ConstraintViolationException;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+@Slf4j
+public class SemanticAnalysisExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, Object>> handleIllegalArgumentException(IllegalArgumentException ex) {
+        log.warn("Invalid argument in semantic analysis service: {}", ex.getMessage());
+        Map<String, Object> error = new HashMap<>();
+        error.put("timestamp", LocalDateTime.now());
+        error.put("status", HttpStatus.BAD_REQUEST.value());
+        error.put("error", "Bad Request");
+        error.put("message", ex.getMessage());
+        error.put("path", "/api/v1/semantic-analysis");
+        return ResponseEntity.badRequest().body(error);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, Object>> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        Map<String, Object> error = new HashMap<>();
+        error.put("timestamp", LocalDateTime.now());
+        error.put("status", HttpStatus.BAD_REQUEST.value());
+        error.put("error", "Validation Failed");
+
+        Map<String, String> fieldErrors = new HashMap<>();
+        ex.getBindingResult().getFieldErrors().forEach(fieldError ->
+                fieldErrors.put(fieldError.getField(), fieldError.getDefaultMessage())
+        );
+
+        error.put("fieldErrors", fieldErrors);
+        error.put("path", "/api/v1/semantic-analysis");
+        return ResponseEntity.badRequest().body(error);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<Map<String, Object>> handleConstraintViolationException(ConstraintViolationException ex) {
+        Map<String, Object> error = new HashMap<>();
+        error.put("timestamp", LocalDateTime.now());
+        error.put("status", HttpStatus.BAD_REQUEST.value());
+        error.put("error", "Constraint Violation");
+        error.put("message", ex.getMessage());
+        error.put("path", "/api/v1/semantic-analysis");
+        return ResponseEntity.badRequest().body(error);
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<Map<String, Object>> handleRuntimeException(RuntimeException ex) {
+        log.error("Runtime exception in semantic analysis service: ", ex);
+        Map<String, Object> error = new HashMap<>();
+        error.put("timestamp", LocalDateTime.now());
+        error.put("status", HttpStatus.INTERNAL_SERVER_ERROR.value());
+        error.put("error", "Internal Server Error");
+        error.put("message", "An error occurred while processing the semantic analysis");
+        error.put("path", "/api/v1/semantic-analysis");
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, Object>> handleGenericException(Exception ex) {
+        log.error("Unexpected exception in semantic analysis service: ", ex);
+        Map<String, Object> error = new HashMap<>();
+        error.put("timestamp", LocalDateTime.now());
+        error.put("status", HttpStatus.INTERNAL_SERVER_ERROR.value());
+        error.put("error", "Internal Server Error");
+        error.put("message", "An unexpected error occurred");
+        error.put("path", "/api/v1/semantic-analysis");
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
+    }
+}

--- a/backend/src/main/java/com/group4/vibeWrite/SemanticAnalysis/repository/SemanticAnalysisRepository.java
+++ b/backend/src/main/java/com/group4/vibeWrite/SemanticAnalysis/repository/SemanticAnalysisRepository.java
@@ -1,0 +1,33 @@
+package com.group4.vibeWrite.SemanticAnalysis.repository;
+
+import com.group4.vibeWrite.SemanticAnalysis.entity.SemanticAnalysisHistory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface SemanticAnalysisRepository extends MongoRepository<SemanticAnalysisHistory, String> {
+
+    List<SemanticAnalysisHistory> findByUserIdOrderByAnalyzedAtDesc(String userId);
+    Page<SemanticAnalysisHistory> findByUserIdOrderByAnalyzedAtDesc(String userId, Pageable pageable);
+    List<SemanticAnalysisHistory> findByUserIdAndAnalyzedAtBetweenOrderByAnalyzedAtDesc(
+            String userId, LocalDateTime startDate, LocalDateTime endDate);
+    List<SemanticAnalysisHistory> findByUserIdAndComplexityScoreGreaterThanEqualOrderByAnalyzedAtDesc(
+            String userId, int minScore);
+    long countByUserId(String userId);
+
+    @Query("{ 'userId': ?0 }")
+    List<SemanticAnalysisHistory> findByUserIdForAverageCalculation(String userId);
+
+    @Query("{ 'userId': ?0, 'analyzedAt': { $gte: ?1 } }")
+    List<SemanticAnalysisHistory> findRecentAnalysesByUserId(String userId, LocalDateTime thirtyDaysAgo);
+
+    void deleteByAnalyzedAtBefore(LocalDateTime cutoffDate);
+    List<SemanticAnalysisHistory> findTop10ByUserIdOrderByComplexityScoreDescAnalyzedAtDesc(String userId);
+}
+

--- a/backend/src/main/java/com/group4/vibeWrite/SemanticAnalysis/service/LemmaService.java
+++ b/backend/src/main/java/com/group4/vibeWrite/SemanticAnalysis/service/LemmaService.java
@@ -1,0 +1,40 @@
+package com.group4.vibeWrite.SemanticAnalysis.service;
+
+// Removed: import com.group4.vibeWrite.SemanticAnalysis.util.Pipeline; <-- No longer needed
+
+import edu.stanford.nlp.ling.CoreLabel;
+import edu.stanford.nlp.pipeline.CoreDocument;
+import edu.stanford.nlp.pipeline.StanfordCoreNLP;
+import org.springframework.stereotype.Service;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class LemmaService {
+
+    private final StanfordCoreNLP stanfordCoreNLP;
+
+    public LemmaService(StanfordCoreNLP stanfordCoreNLP) {
+        this.stanfordCoreNLP = stanfordCoreNLP;
+    }
+
+    public Map<String, String> lemmatizeText(String text) {
+
+        CoreDocument coreDocument = new CoreDocument(text);
+
+        // Use the injected pipeline instance
+        stanfordCoreNLP.annotate(coreDocument);
+
+        Map<String, String> lemmaResults = new LinkedHashMap<>();
+        List<CoreLabel> coreLabelList = coreDocument.tokens();
+
+        for (CoreLabel coreLabel : coreLabelList) {
+            String lemma = coreLabel.lemma();
+            lemmaResults.put(coreLabel.originalText(), lemma);
+        }
+
+        return lemmaResults;
+    }
+}

--- a/backend/src/main/java/com/group4/vibeWrite/SemanticAnalysis/service/NERService.java
+++ b/backend/src/main/java/com/group4/vibeWrite/SemanticAnalysis/service/NERService.java
@@ -1,0 +1,43 @@
+package com.group4.vibeWrite.SemanticAnalysis.service;
+
+// Removed: import com.group4.vibeWrite.SemanticAnalysis.util.Pipeline; <-- Not needed anymore
+
+import edu.stanford.nlp.ling.CoreAnnotations;
+import edu.stanford.nlp.ling.CoreLabel;
+import edu.stanford.nlp.pipeline.CoreDocument;
+import edu.stanford.nlp.pipeline.StanfordCoreNLP;
+import org.springframework.stereotype.Service;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class NERService {
+
+    private final StanfordCoreNLP stanfordCoreNLP;
+
+    public NERService(StanfordCoreNLP stanfordCoreNLP) {
+        this.stanfordCoreNLP = stanfordCoreNLP;
+    }
+
+    public Map<String, String> extractNamedEntities(String text) {
+
+        CoreDocument coreDocument = new CoreDocument(text);
+
+        // Use the injected pipeline
+        this.stanfordCoreNLP.annotate(coreDocument);
+
+        Map<String, String> nerResults = new LinkedHashMap<>();
+        List<CoreLabel> coreLabelList = coreDocument.tokens();
+
+        for (CoreLabel coreLabel : coreLabelList) {
+            String ner = coreLabel.getString(CoreAnnotations.NamedEntityTagAnnotation.class);
+            if (!"O".equals(ner)) {
+                nerResults.put(coreLabel.originalText(), ner);
+            }
+        }
+
+        return nerResults;
+    }
+}

--- a/backend/src/main/java/com/group4/vibeWrite/SemanticAnalysis/service/POSService.java
+++ b/backend/src/main/java/com/group4/vibeWrite/SemanticAnalysis/service/POSService.java
@@ -1,0 +1,41 @@
+package com.group4.vibeWrite.SemanticAnalysis.service;
+
+// Removed: import com.group4.vibeWrite.SemanticAnalysis.util.Pipeline; <-- Not needed anymore
+
+import edu.stanford.nlp.ling.CoreAnnotations;
+import edu.stanford.nlp.ling.CoreLabel;
+import edu.stanford.nlp.pipeline.CoreDocument;
+import edu.stanford.nlp.pipeline.StanfordCoreNLP;
+import org.springframework.stereotype.Service;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class POSService {
+
+    private final StanfordCoreNLP stanfordCoreNLP;
+
+    public POSService(StanfordCoreNLP stanfordCoreNLP) {
+        this.stanfordCoreNLP = stanfordCoreNLP;
+    }
+
+    public Map<String, String> getPOSTags(String text) {
+
+        CoreDocument coreDocument = new CoreDocument(text);
+
+        // Use the injected pipeline instance
+        stanfordCoreNLP.annotate(coreDocument);
+
+        Map<String, String> posTags = new LinkedHashMap<>();
+        List<CoreLabel> coreLabels = coreDocument.tokens();
+
+        for (CoreLabel coreLabel : coreLabels) {
+            String pos = coreLabel.get(CoreAnnotations.PartOfSpeechAnnotation.class);
+            posTags.put(coreLabel.originalText(), pos);
+        }
+
+        return posTags;
+    }
+}

--- a/backend/src/main/java/com/group4/vibeWrite/SemanticAnalysis/service/SemanticAnalysisOrchestrator.java
+++ b/backend/src/main/java/com/group4/vibeWrite/SemanticAnalysis/service/SemanticAnalysisOrchestrator.java
@@ -1,0 +1,307 @@
+package com.group4.vibeWrite.SemanticAnalysis.service;
+
+import com.group4.vibeWrite.SemanticAnalysis.dto.SemanticAnalysisRequest;
+import com.group4.vibeWrite.SemanticAnalysis.dto.SemanticAnalysisResponse;
+import com.group4.vibeWrite.SemanticAnalysis.entity.SemanticAnalysisHistory;
+import com.group4.vibeWrite.SemanticAnalysis.repository.SemanticAnalysisRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SemanticAnalysisOrchestrator {
+
+    // Keep your existing services
+    private final TokenizeService tokenizeService;
+    private final SentenceRecognizerService sentenceRecognizerService;
+    private final POSService posService;
+    private final LemmaService lemmaService;
+    private final NERService nerService;
+    private final SentimentAnalysisService sentimentAnalysisService;
+
+    // New repository for history management
+    private final SemanticAnalysisRepository repository;
+
+    // Getter methods for controller access
+    public TokenizeService getTokenizeService() { return tokenizeService; }
+    public SentenceRecognizerService getSentenceRecognizerService() { return sentenceRecognizerService; }
+    public POSService getPosService() { return posService; }
+    public LemmaService getLemmaService() { return lemmaService; }
+    public NERService getNerService() { return nerService; }
+    public SentimentAnalysisService getSentimentAnalysisService() { return sentimentAnalysisService; }
+
+    public SemanticAnalysisResponse performCompleteAnalysis(SemanticAnalysisRequest request, String userId) {
+        String text = request.getText();
+
+        if (text == null || text.trim().isEmpty()) {
+            return SemanticAnalysisResponse.builder()
+                    .error("Input text cannot be empty")
+                    .build();
+        }
+
+        try {
+            // Use your existing services
+            List<String> tokens = tokenizeService.tokenizeText(text);
+            List<String> sentences = sentenceRecognizerService.recognizeSentences(text);
+            Map<String, String> posTags = posService.getPOSTags(text);
+            Map<String, String> lemmas = lemmaService.lemmatizeText(text);
+            Map<String, String> namedEntities = nerService.extractNamedEntities(text);
+            Map<String, String> sentiment = sentimentAnalysisService.analyzeSentiment(text);
+
+            // New enhanced metrics calculation
+            SemanticAnalysisResponse.SemanticMetrics metrics = calculateEnhancedMetrics(
+                    text, tokens, sentences, posTags, lemmas, namedEntities, sentiment);
+
+            // New complexity scoring
+            int complexityScore = calculateComplexityScore(text, tokens, sentences, posTags,
+                    namedEntities, metrics);
+
+            SemanticAnalysisResponse response = SemanticAnalysisResponse.builder()
+                    .originalText(text)
+                    .tokens(tokens)
+                    .sentences(sentences)
+                    .posTags(posTags)
+                    .lemmas(lemmas)
+                    .namedEntities(namedEntities)
+                    .sentiment(sentiment)
+                    .metrics(metrics)
+                    .complexityScore(complexityScore)
+                    .analyzedAt(LocalDateTime.now())
+                    .build();
+
+            // Save to history if userId provided
+            if (userId != null && !userId.trim().isEmpty()) {
+                saveToHistory(response, userId);
+            }
+
+            return response;
+
+        } catch (Exception e) {
+            log.error("Error in semantic analysis: ", e);
+            return SemanticAnalysisResponse.builder()
+                    .originalText(text)
+                    .error("Analysis failed: " + e.getMessage())
+                    .build();
+        }
+    }
+
+    private SemanticAnalysisResponse.SemanticMetrics calculateEnhancedMetrics(
+            String text, List<String> tokens, List<String> sentences,
+            Map<String, String> posTags, Map<String, String> lemmas,
+            Map<String, String> namedEntities, Map<String, String> sentiment) {
+
+        int wordCount = tokens.size();
+        int sentenceCount = Math.max(1, sentences.size());
+        Set<String> uniqueWords = new HashSet<>(tokens.stream()
+                .map(String::toLowerCase).collect(Collectors.toList()));
+        int uniqueWordCount = uniqueWords.size();
+        int namedEntityCount = namedEntities.size();
+
+        double avgWordsPerSentence = (double) wordCount / sentenceCount;
+        double lexicalDiversity = wordCount > 0 ? (double) uniqueWordCount / wordCount : 0;
+
+        Map<String, Integer> posTagCounts = posTags.values().stream()
+                .collect(Collectors.groupingBy(tag -> tag,
+                        Collectors.collectingAndThen(Collectors.counting(), Math::toIntExact)));
+
+        Map<String, Integer> sentimentDistribution = sentiment.values().stream()
+                .collect(Collectors.groupingBy(s -> s,
+                        Collectors.collectingAndThen(Collectors.counting(), Math::toIntExact)));
+
+        Map<String, Integer> entityTypeCounts = namedEntities.values().stream()
+                .collect(Collectors.groupingBy(type -> type,
+                        Collectors.collectingAndThen(Collectors.counting(), Math::toIntExact)));
+
+        long meaningfulWords = posTags.values().stream()
+                .filter(pos -> pos.startsWith("NN") || pos.startsWith("VB") ||
+                        pos.startsWith("JJ") || pos.startsWith("RB"))
+                .count();
+        double semanticDensity = wordCount > 0 ? (double) meaningfulWords / wordCount : 0;
+
+        return SemanticAnalysisResponse.SemanticMetrics.builder()
+                .wordCount(wordCount)
+                .sentenceCount(sentenceCount)
+                .uniqueWordCount(uniqueWordCount)
+                .namedEntityCount(namedEntityCount)
+                .averageWordsPerSentence(avgWordsPerSentence)
+                .lexicalDiversity(lexicalDiversity)
+                .posTagCounts(posTagCounts)
+                .sentimentDistribution(sentimentDistribution)
+                .entityTypeCounts(entityTypeCounts)
+                .semanticDensity(semanticDensity)
+                .build();
+    }
+
+    private int estimateSyllables(String word) {
+        word = word.toLowerCase().replaceAll("[^a-z]", "");
+        if (word.length() == 0) return 0;
+        int syllables = 0;
+        boolean previousWasVowel = false;
+        for (char c : word.toCharArray()) {
+            boolean isVowel = "aeiouy".indexOf(c) != -1;
+            if (isVowel && !previousWasVowel) syllables++;
+            previousWasVowel = isVowel;
+        }
+        if (word.endsWith("e") && syllables > 1) syllables--;
+        return Math.max(1, syllables);
+    }
+
+    private int calculateComplexityScore(String text, List<String> tokens, List<String> sentences,
+                                         Map<String, String> posTags, Map<String, String> namedEntities,
+                                         SemanticAnalysisResponse.SemanticMetrics metrics) {
+        int baseScore = 50;
+        if (metrics.getLexicalDiversity() > 0.7) baseScore += 15;
+        else if (metrics.getLexicalDiversity() > 0.5) baseScore += 10;
+        else if (metrics.getLexicalDiversity() < 0.3) baseScore -= 10;
+
+        if (metrics.getAverageWordsPerSentence() > 20) baseScore += 10;
+        else if (metrics.getAverageWordsPerSentence() > 15) baseScore += 5;
+        else if (metrics.getAverageWordsPerSentence() < 8) baseScore -= 5;
+
+        double entityDensity = (double) namedEntities.size() / Math.max(1, tokens.size());
+        if (entityDensity > 0.1) baseScore += 10;
+        else if (entityDensity > 0.05) baseScore += 5;
+
+        Set<String> uniquePosTags = new HashSet<>(posTags.values());
+        if (uniquePosTags.size() > 15) baseScore += 10;
+        else if (uniquePosTags.size() > 10) baseScore += 5;
+
+        if (metrics.getSemanticDensity() > 0.6) baseScore += 10;
+        else if (metrics.getSemanticDensity() > 0.4) baseScore += 5;
+
+        if (tokens.size() > 200) baseScore += 5;
+        else if (tokens.size() < 20) baseScore -= 10;
+
+        return Math.max(0, Math.min(100, baseScore));
+    }
+
+    private void saveToHistory(SemanticAnalysisResponse response, String userId) {
+        try {
+            SemanticAnalysisHistory.SemanticMetrics historyMetrics =
+                    new SemanticAnalysisHistory.SemanticMetrics(
+                            response.getMetrics().getWordCount(),
+                            response.getMetrics().getSentenceCount(),
+                            response.getMetrics().getUniqueWordCount(),
+                            response.getMetrics().getNamedEntityCount(),
+                            response.getMetrics().getAverageWordsPerSentence(),
+                            response.getMetrics().getLexicalDiversity(),
+                            response.getMetrics().getReadabilityScore(),
+                            response.getMetrics().getPosTagCounts(),
+                            response.getMetrics().getSentimentDistribution(),
+                            response.getMetrics().getEntityTypeCounts(),
+                            response.getMetrics().getSemanticDensity()
+                    );
+
+            SemanticAnalysisHistory history = new SemanticAnalysisHistory(
+                    userId, response.getOriginalText(), response.getTokens(),
+                    response.getSentences(), response.getPosTags(), response.getLemmas(),
+                    response.getNamedEntities(), response.getSentiment(),
+                    historyMetrics, response.getComplexityScore()
+            );
+
+            repository.save(history);
+        } catch (Exception e) {
+            log.error("Error saving semantic analysis history: ", e);
+        }
+    }
+
+    // History management methods
+    public List<SemanticAnalysisHistory> getUserSemanticHistory(String userId) {
+        return repository.findByUserIdOrderByAnalyzedAtDesc(userId);
+    }
+
+    public Page<SemanticAnalysisHistory> getUserSemanticHistory(String userId, Pageable pageable) {
+        return repository.findByUserIdOrderByAnalyzedAtDesc(userId, pageable);
+    }
+
+    public Optional<SemanticAnalysisHistory> getSemanticAnalysisById(String id) {
+        return repository.findById(id);
+    }
+
+    public Map<String, Object> getUserSemanticStats(String userId) {
+        List<SemanticAnalysisHistory> history = repository.findByUserIdOrderByAnalyzedAtDesc(userId);
+        if (history.isEmpty()) {
+            return Map.of("totalAnalyses", 0L, "averageComplexityScore", 0.0);
+        }
+        double averageComplexity = history.stream()
+                .mapToInt(SemanticAnalysisHistory::getComplexityScore).average().orElse(0.0);
+        return Map.of(
+                "totalAnalyses", (long) history.size(),
+                "averageComplexityScore", Math.round(averageComplexity * 100.0) / 100.0,
+                "totalWordsAnalyzed", history.stream().mapToInt(h -> h.getMetrics().getWordCount()).sum()
+        );
+    }
+
+    public Map<String, Object> getDetailedUserStats(String userId) {
+        List<SemanticAnalysisHistory> history = repository.findByUserIdOrderByAnalyzedAtDesc(userId);
+        if (history.isEmpty()) {
+            return Map.of("error", "No analysis history found for user");
+        }
+
+        Map<String, Long> entityTypeTotals = new HashMap<>();
+        Map<String, Long> posTagTotals = new HashMap<>();
+
+        for (SemanticAnalysisHistory analysis : history) {
+            if (analysis.getMetrics().getEntityTypeCounts() != null) {
+                analysis.getMetrics().getEntityTypeCounts().forEach((k, v) ->
+                        entityTypeTotals.merge(k, (long) v, Long::sum));
+            }
+            if (analysis.getMetrics().getPosTagCounts() != null) {
+                analysis.getMetrics().getPosTagCounts().forEach((k, v) ->
+                        posTagTotals.merge(k, (long) v, Long::sum));
+            }
+        }
+
+        return Map.of(
+                "totalAnalyses", (long) history.size(),
+                "topEntityTypes", entityTypeTotals.entrySet().stream()
+                        .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+                        .limit(5).collect(Collectors.toMap(
+                                Map.Entry::getKey, Map.Entry::getValue)),
+                "topPOSTags", posTagTotals.entrySet().stream()
+                        .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+                        .limit(5).collect(Collectors.toMap(
+                                Map.Entry::getKey, Map.Entry::getValue))
+        );
+    }
+
+    public Map<String, Object> getAnalysisTrends(String userId) {
+        LocalDateTime thirtyDaysAgo = LocalDateTime.now().minusDays(30);
+        List<SemanticAnalysisHistory> recentHistory = repository.findRecentAnalysesByUserId(userId, thirtyDaysAgo);
+
+        if (recentHistory.isEmpty()) {
+            return Map.of("message", "No recent analyses in the last 30 days.");
+        }
+
+        Map<String, List<SemanticAnalysisHistory>> groupedByDay = recentHistory.stream()
+                .collect(Collectors.groupingBy(h -> h.getAnalyzedAt().toLocalDate().toString()));
+
+        Map<String, Map<String, Double>> dailyTrends = groupedByDay.entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        e -> Map.of(
+                                "avgComplexity", e.getValue().stream()
+                                        .mapToInt(SemanticAnalysisHistory::getComplexityScore)
+                                        .average().orElse(0.0),
+                                "avgLexicalDiversity", e.getValue().stream()
+                                        .mapToDouble(h -> h.getMetrics().getLexicalDiversity())
+                                        .average().orElse(0.0),
+                                "analysisCount", (double) e.getValue().size()
+                        )
+                ));
+
+        return Map.of(
+                "recentAnalysisCount", recentHistory.size(),
+                "dailyTrends", new TreeMap<>(dailyTrends),
+                "topComplexAnalyses", repository.findTop10ByUserIdOrderByComplexityScoreDescAnalyzedAtDesc(userId)
+        );
+    }
+}

--- a/backend/src/main/java/com/group4/vibeWrite/SemanticAnalysis/service/SentenceRecognizerService.java
+++ b/backend/src/main/java/com/group4/vibeWrite/SemanticAnalysis/service/SentenceRecognizerService.java
@@ -1,0 +1,35 @@
+package com.group4.vibeWrite.SemanticAnalysis.service;
+
+// REMOVED: import com.group4.vibeWrite.SemanticAnalysis.util.Pipeline;
+import edu.stanford.nlp.pipeline.CoreDocument;
+import edu.stanford.nlp.pipeline.CoreSentence;
+import edu.stanford.nlp.pipeline.StanfordCoreNLP;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class SentenceRecognizerService {
+
+    private final StanfordCoreNLP stanfordCoreNLP;
+
+    public SentenceRecognizerService(StanfordCoreNLP stanfordCoreNLP) {
+        this.stanfordCoreNLP = stanfordCoreNLP;
+    }
+
+    public List<String> recognizeSentences(String text) {
+
+        CoreDocument coreDocument = new CoreDocument(text);
+        stanfordCoreNLP.annotate(coreDocument);
+
+        List<String> sentenceList = new ArrayList<>();
+        List<CoreSentence> sentences = coreDocument.sentences();
+
+        for (CoreSentence sentence : sentences) {
+            sentenceList.add(sentence.toString());
+        }
+
+        return sentenceList;
+    }
+}

--- a/backend/src/main/java/com/group4/vibeWrite/SemanticAnalysis/service/SentimentAnalysisService.java
+++ b/backend/src/main/java/com/group4/vibeWrite/SemanticAnalysis/service/SentimentAnalysisService.java
@@ -1,0 +1,37 @@
+package com.group4.vibeWrite.SemanticAnalysis.service;
+
+// REMOVED: import com.group4.vibeWrite.SemanticAnalysis.util.Pipeline;
+import edu.stanford.nlp.pipeline.CoreDocument;
+import edu.stanford.nlp.pipeline.CoreSentence;
+import edu.stanford.nlp.pipeline.StanfordCoreNLP;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class SentimentAnalysisService {
+
+    private final StanfordCoreNLP stanfordCoreNLP;
+
+    public SentimentAnalysisService(StanfordCoreNLP stanfordCoreNLP) {
+        this.stanfordCoreNLP = stanfordCoreNLP;
+    }
+
+    public Map<String, String> analyzeSentiment(String text) {
+
+        Map<String, String> results = new HashMap<>();
+        CoreDocument coreDocument = new CoreDocument(text);
+
+        stanfordCoreNLP.annotate(coreDocument);
+
+        List<CoreSentence> sentences = coreDocument.sentences();
+        for (CoreSentence sentence : sentences) {
+            String sentiment = sentence.sentiment();
+            results.put(sentence.toString(), sentiment);
+        }
+
+        return results;
+    }
+}

--- a/backend/src/main/java/com/group4/vibeWrite/SemanticAnalysis/service/TokenizeService.java
+++ b/backend/src/main/java/com/group4/vibeWrite/SemanticAnalysis/service/TokenizeService.java
@@ -1,0 +1,35 @@
+package com.group4.vibeWrite.SemanticAnalysis.service;
+
+// REMOVED: import com.group4.vibeWrite.SemanticAnalysis.util.Pipeline;
+import edu.stanford.nlp.ling.CoreLabel;
+import edu.stanford.nlp.pipeline.CoreDocument;
+import edu.stanford.nlp.pipeline.StanfordCoreNLP;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class TokenizeService {
+
+    private final StanfordCoreNLP stanfordCoreNLP;
+
+    public TokenizeService(StanfordCoreNLP stanfordCoreNLP) {
+        this.stanfordCoreNLP = stanfordCoreNLP;
+    }
+
+    public List<String> tokenizeText(String text) {
+
+        CoreDocument coreDocument = new CoreDocument(text);
+        stanfordCoreNLP.annotate(coreDocument);
+
+        List<String> tokenList = new ArrayList<>();
+        List<CoreLabel> coreLabelList = coreDocument.tokens();
+
+        for (CoreLabel coreLabel : coreLabelList) {
+            tokenList.add(coreLabel.originalText());
+        }
+
+        return tokenList;
+    }
+}

--- a/backend/src/main/java/com/group4/vibeWrite/SemanticAnalysis/util/Pipeline.java
+++ b/backend/src/main/java/com/group4/vibeWrite/SemanticAnalysis/util/Pipeline.java
@@ -1,0 +1,20 @@
+package com.group4.vibeWrite.SemanticAnalysis.util;
+
+import edu.stanford.nlp.pipeline.StanfordCoreNLP;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import java.util.Properties;
+
+@Configuration
+public class Pipeline {
+
+    private static final String PROPERTIES_NAME = "tokenize,ssplit,pos,lemma,ner,parse,sentiment";
+
+    @Bean
+    public StanfordCoreNLP stanfordCoreNLP() {
+        Properties properties = new Properties();
+        properties.setProperty("annotators", PROPERTIES_NAME);
+        properties.setProperty("sentiment.model", "edu/stanford/nlp/models/sentiment/sentiment.ser.gz");
+        return new StanfordCoreNLP(properties);
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -65,9 +65,3 @@ spring.cache.caffeine.spec=maximumSize=1000,expireAfterWrite=1h
 management.endpoints.web.exposure.include=health,info,metrics
 management.endpoint.health.show-details=when-authorized
 management.metrics.export.simple.enabled=true
-
-# Application Info
-info.app.name=@project.name@
-info.app.description=@project.description@
-info.app.version=@project.version@
-info.app.java.version=@java.version@

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,2 +1,2 @@
-# VITE_BACKEND_URL =http://localhost:8080
+#VITE_BACKEND_URL =http://localhost:8080
 VITE_BACKEND_URL =https://vibewrite-app.onrender.com


### PR DESCRIPTION
Added the backend of sentiment analysis feathure using the Stanford CoreNLP library 
This pull request adds the Semantic Analysis Controller, providing multiple endpoints for natural language processing and history tracking. The endpoints include /analyze for full semantic analysis of text for authenticated users, /analyze-anonymous for anonymous analysis, /tokenize to split text into tokens, /sentences to break text into sentences, /pos for part-of-speech tagging, /lemma for lemmatization, /ner for named entity recognition, and /sentiment for sentiment analysis. It also includes /history/user/{userId} to retrieve a user’s analysis history, /history/{id} to fetch a specific analysis record, /history/paginated for paginated history retrieval, /stats and /stats/detailed for summary and detailed analysis statistics, /trends to obtain semantic analysis trends, and /health for a service status check. These additions enhance the application by providing robust semantic analysis capabilities and comprehensive history tracking.